### PR TITLE
Jib unbreak python 2.x

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -29,7 +29,7 @@ Example
 
 Using pybloom is very simple, and is similar to using native sets::
 
-    from pybloom import BloomdClient
+    from pybloomd.pybloomd import BloomdClient
 
     # Create a client to a local bloomd server, default port
     client = BloomdClient(["localhost"])
@@ -43,7 +43,7 @@ Using pybloom is very simple, and is similar to using native sets::
 
 To support multiple servers, just add multiple servers::
 
-    from pybloom import BloomdClient
+    from pybloomd.pybloomd import BloomdClient
 
     # Create a client to a multiple bloomd servers, default ports
     client = BloomdClient(["bloomd1", "bloomd2"])
@@ -65,7 +65,7 @@ To support multiple servers, just add multiple servers::
 
 Using pipelining is straightforward as well::
 
-    from pybloom import BloomdClient
+    from pybloomd.pybloomd import BloomdClient
 
     # Create a client to a local bloomd server, default port
     client = BloomdClient(["localhost"])

--- a/pybloomd/pybloomd.py
+++ b/pybloomd/pybloomd.py
@@ -67,7 +67,8 @@ class BloomdConnection(object):
         sent = False
         for attempt in range(self.attempts):
             try:
-                self.sock.sendall(str.encode(cmd + '\n'))
+                cmd += '\n'
+                self.sock.sendall(cmd.encode())
                 sent = True
                 break
             except socket.error as e:


### PR DESCRIPTION
Your change to [fix for python 3](https://github.com/brunoalano/bloom-python-driver/commit/b75a9340dca49d0be45e5aa73c238f5217d699c5#diff-f6e8cb0fe5319f08c06a02b4b0f4a728R70) broke python 2.x:

```
 File "/Users/jib/.python/krux-adimpression-stream/lib/python2.7/site-packages/pybloomd/pybloomd.py", line 70, in send
    self.sock.sendall(str.encode(cmd + '\n'))
TypeError: descriptor 'encode' requires a 'str' object but received a 'unicode'
```

This restores python 2 compatibility, by calling encode correctly on the variables, as opposed to incorrectly on the `str` class

In addition, I updated the Readme to accurately reflect the usage of the package.
